### PR TITLE
Access Control Handling on Install

### DIFF
--- a/src/main/java/com/cognifide/maven/plugins/crx/AcHandling.java
+++ b/src/main/java/com/cognifide/maven/plugins/crx/AcHandling.java
@@ -1,0 +1,36 @@
+package com.cognifide.maven.plugins.crx;
+
+/**
+ * AcHandling - Enum to represent the Access Control Options for package installs for CQ via command. According to Adobe, only supported options are:
+ *
+ * Ignore - default setting,  ignores the packaged access control and leaves the target unchanged.
+ * Clear -  clears all access control on the target system.
+ * Overwrite - applies the access control provided with the package to the target. This also removes the existing access controls.
+ *
+ * See for more details - http://dev.day.com/docs/en/crx/current/how_to/package_manager.html#Installing packages (CLI)
+ */
+public enum AcHandling {
+
+	IGNORE("ignore"),
+	CLEAR("clear"),
+	OVERWRITE("overwrite");
+
+	private final String id;
+
+	private AcHandling(String id){
+		this.id = id;
+	}
+
+	public static AcHandling ofId(String id){
+		for(AcHandling handle : AcHandling.values()){
+			if(handle.getId().equalsIgnoreCase(id)){
+				return handle;
+			}
+		}
+		return null;
+	}
+
+	public String getId(){
+		return this.id;
+	}
+}

--- a/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageInstallMojo.java
+++ b/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageInstallMojo.java
@@ -36,6 +36,15 @@ public class CrxPackageInstallMojo extends CrxPackageAbstractMojo {
 	 */
 	private String packagePath;
 
+	/**
+	 *
+	 * Determines how access control nodes should be handled on install
+	 *
+	 * @parameter expression="${acHandling}"
+	 *
+	 */
+	protected String acHandling;
+
 	private String uploadedPackagePath;
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
@@ -92,12 +101,34 @@ public class CrxPackageInstallMojo extends CrxPackageAbstractMojo {
 	}
 
 	protected String getInstallURL(String path) {
-		return getHtmlTargetURL() + path + "/?cmd=install";
+		String installPath = getHtmlTargetURL() + path + "/?cmd=install";
+		return appendAcHandlingParam(installPath);
 	}
 
 	protected void displayErrors(List<String> errors) {
 		for (String error : errors) {
 			getLog().error("CRX: " + error);
 		}
+	}
+
+	protected String appendAcHandlingParam(String path){
+		StringBuilder commandPath = new StringBuilder(path);
+		String acParam = formatAcHandling();
+
+		if(StringUtils.isNotBlank(acParam)){
+			commandPath.append("?");
+			commandPath.append(acParam);
+		}
+
+		return commandPath.toString();
+	}
+
+	protected String formatAcHandling(){
+		AcHandling handle = AcHandling.ofId(acHandling);
+		String command = "";
+		if(handle!=null){
+			command = "acHandling="+handle.getId();
+		}
+		return command;
 	}
 }

--- a/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageInstallMojo.java
+++ b/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageInstallMojo.java
@@ -116,7 +116,7 @@ public class CrxPackageInstallMojo extends CrxPackageAbstractMojo {
 		String acParam = formatAcHandling();
 
 		if(StringUtils.isNotBlank(acParam)){
-			commandPath.append("?");
+			commandPath.append("&");
 			commandPath.append(acParam);
 		}
 


### PR DESCRIPTION
Adding optional property for users to specify how they want CQ to handle access control nodes for package install. By default, any access control nodes in the package will be ignored and the nodes in target environment will remain untouched.
