### PR TITLE
crx package manager status check goal implementation

### DIFF
--- a/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageManagerStatusMojo.java
+++ b/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageManagerStatusMojo.java
@@ -1,0 +1,81 @@
+package com.cognifide.maven.plugins.crx;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.io.IOException;
+
+/**
+ * Checks if CRX Package Manager service is running.
+ *
+ * @goal statusCheck
+ * @description Checking if CRX Package Manager service is running.
+ *
+ * @execute goal='statusCheck'
+ */
+public class CrxPackageManagerStatusMojo extends CrxPackageAbstractMojo {
+
+	/**
+	 * Defines how many times CRX Package Manager service status will be checked.
+	 *
+	 * @parameter expression="${crx.retryCount}" default-value="1"
+	 */
+	private int retryCount;
+
+	/**
+	 * Defines interval between each CRX Package Manager service call.
+	 *
+	 * @parameter expression="${crx.waitingTime}" default-value="2000"
+	 */
+	private long waitingTime;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		checkStatus(getJspTargetURL());
+	}
+
+	private void checkStatus(String targetURL) throws MojoExecutionException {
+		try {
+			int count = 1;
+			while (count <= retryCount) {
+				getLog().info(String.format("Trying connect to CRX Package Manager service (%s)... [%d/%d]",
+						targetURL, count, retryCount));
+				if (getStatus(targetURL) != HttpStatus.SC_OK) {
+					getLog().warn("Cannot connect to CRX Package Manager service");
+
+					if (count++ == retryCount) {
+						throw new MojoExecutionException("CRX Package Manager service is not accessible.");
+					}
+
+					Thread.sleep(waitingTime);
+					continue;
+				}
+				getLog().info("CRX Package Manager service is up and running.");
+				break;
+			}
+		} catch (InterruptedException e) {
+			getLog().error(e);
+		}
+	}
+
+	private int getStatus(String targetURL) throws MojoExecutionException {
+		final GetMethod getMethod = new GetMethod(targetURL);
+		int status;
+		try {
+			status = getHttpClient().executeMethod(getMethod);
+		} catch (IOException e) {
+			throw new MojoExecutionException(
+					"Request to the CRX Package Manager service failed, cause: " + e.getMessage(),
+					e);
+		} finally {
+			getMethod.releaseConnection();
+		}
+		return status;
+	}
+
+	private String getJspTargetURL() {
+		return this.url + this.packageManagerSuffix + ".jsp";
+	}
+}

--- a/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageManagerStatusMojo.java
+++ b/src/main/java/com/cognifide/maven/plugins/crx/CrxPackageManagerStatusMojo.java
@@ -33,30 +33,31 @@ public class CrxPackageManagerStatusMojo extends CrxPackageAbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		checkStatus(getJspTargetURL());
+		try {
+			checkStatus(getJspTargetURL());
+		} catch (InterruptedException e) {
+			getLog().error("Cannot connect to CRX Package Manager service", e);
+			throw new MojoExecutionException("CRX Package Manager service connection failed");
+		}
 	}
 
-	private void checkStatus(String targetURL) throws MojoExecutionException {
-		try {
-			int count = 1;
-			while (count <= retryCount) {
-				getLog().info(String.format("Trying connect to CRX Package Manager service (%s)... [%d/%d]",
-						targetURL, count, retryCount));
-				if (getStatus(targetURL) != HttpStatus.SC_OK) {
-					getLog().warn("Cannot connect to CRX Package Manager service");
+	private void checkStatus(String targetURL) throws InterruptedException, MojoExecutionException {
+		int count = 1;
+		while (count <= retryCount) {
+			getLog().info(String.format("Trying connect to CRX Package Manager service (%s)... [%d/%d]",
+					targetURL, count, retryCount));
+			if (getStatus(targetURL) != HttpStatus.SC_OK) {
+				getLog().warn("Cannot connect to CRX Package Manager service");
 
-					if (count++ == retryCount) {
-						throw new MojoExecutionException("CRX Package Manager service is not accessible.");
-					}
-
-					Thread.sleep(waitingTime);
-					continue;
+				if (count++ == retryCount) {
+					throw new MojoExecutionException("CRX Package Manager service is not accessible.");
 				}
-				getLog().info("CRX Package Manager service is up and running.");
-				break;
+
+				Thread.sleep(waitingTime);
+				continue;
 			}
-		} catch (InterruptedException e) {
-			getLog().error(e);
+			getLog().info("CRX Package Manager service is up and running.");
+			break;
 		}
 	}
 


### PR DESCRIPTION
Adding implementation of goal that allows to check crx package manager status. This could be used to prevent situations when crx package upload failed because crx package manager is not responding.